### PR TITLE
Create `pull_from_prod` management command

### DIFF
--- a/nhl-game-predictor-backend/games/management/commands/pull_from_prod.py
+++ b/nhl-game-predictor-backend/games/management/commands/pull_from_prod.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+class Command(BaseCommand):
+  help = "Restores the production Supabase instance with your local database"
+
+  def handle(self, *args, **options):
+    # credentials needed to access local database
+    local_db_name = os.getenv("DATABASE_NAME")
+    local_db_user = os.getenv("DATABASE_USER")
+    local_db_password = os.getenv("DATABASE_PASSWORD")
+    local_db_host = os.getenv("DATABASE_HOST")
+    local_db_port = os.getenv("DATABASE_PORT")
+
+    # credentials needed to access production supabase-hosted database
+    prod_db_name = os.getenv("PROD_DATABASE_NAME")
+    prod_db_user = os.getenv("PROD_DATABASE_USER")
+    prod_db_password = os.getenv("PROD_DATABASE_PASSWORD")
+    prod_db_host = os.getenv("PROD_DATABASE_HOST")
+    prod_db_port = os.getenv("PROD_DATABASE_PORT")
+
+    if not all([local_db_name, local_db_user, local_db_password, local_db_host, local_db_port]):
+      raise CommandError("Missing production DB credentials. Check your env vars.")
+
+    if not all([prod_db_name, prod_db_user, prod_db_password, prod_db_host, prod_db_port]):
+      raise CommandError("Missing production DB credentials. Check your env vars.")
+    
+    confirm = input(
+        "\033[93mWARNING: This will overwrite the LOCAL database. Are you sure? [yes/no]: \033[0m"
+    )
+    if confirm.lower() != "yes":
+      self.stdout.write("Aborting.")
+      return
+
+    # construct the file path for the local dump
+    now = timezone.now().strftime("%Y%m%d_%H%M%S")
+    command_dir = os.path.dirname(os.path.abspath(__file__))
+    dump_dir = os.path.join(command_dir, "prod_db_dumps")
+    dump_file_path = f"{dump_dir}/prod_dump_{now}.dump"
+    os.makedirs(dump_dir, exist_ok=True)
+
+    # dump local DB
+    self.stdout.write("Dumping prod DB...")
+    subprocess.run([
+      "pg_dump",
+      "-Fc",
+      "-h", prod_db_host,
+      "-p", prod_db_port,
+      "-U", prod_db_user,
+      "-d", prod_db_name,
+      "-f", dump_file_path
+    ], check=True, env={"PGPASSWORD": prod_db_password})
+
+    self.stdout.write(f"Dumped prod DB into `{dump_file_path}`.")

--- a/nhl-game-predictor-backend/games/management/commands/pull_from_prod.py
+++ b/nhl-game-predictor-backend/games/management/commands/pull_from_prod.py
@@ -77,3 +77,23 @@ class Command(BaseCommand):
     ], check=True, env={"PGPASSWORD": prod_db_password})
 
     self.stdout.write(f"Dumped prod DB into `{dump_file_path}`.")
+
+    # drop the local DB
+    subprocess.run([
+        "psql",
+        "-h", local_db_host,
+        "-p", local_db_port,
+        "-U", local_db_user,
+        "-d", "postgres",  # connect to a separate DB to run DROP
+        "-c", f"DROP DATABASE IF EXISTS {local_db_name};"
+    ], check=True, env={"PGPASSWORD": local_db_password})
+
+    # recreate the local DB
+    subprocess.run([
+        "psql",
+        "-h", local_db_host,
+        "-p", local_db_port,
+        "-U", local_db_user,
+        "-d", "postgres",
+        "-c", f"CREATE DATABASE {local_db_name};"
+    ], check=True, env={"PGPASSWORD": local_db_password})


### PR DESCRIPTION
This PR:

- adds a management command `python manage.py pull_from_prod`/`poetry run python manage.py pull_from_prod` which restores the production database into the local database for ease during development

closes #73 