### PR TITLE
Assign season to game

### DIFF
--- a/nhl-game-predictor-backend/games/data_loader.py
+++ b/nhl-game-predictor-backend/games/data_loader.py
@@ -6,7 +6,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nhl_game_predictor")
 django.setup()
 
 from django.conf import settings
-from games.models import Franchise, Team, Game, TeamData
+from games.models import Franchise, Team, Game, TeamData, Season
 from django.utils import timezone
 from datetime import timedelta, datetime
 from django.db import transaction
@@ -60,7 +60,10 @@ def convert_game_json_to_game_data_objects(game_json : dict, date_string : str, 
                                                               game_date=game_date)
             
 
+        season_id = game_json.get("season")
+        season = Season.objects.filter(id=season_id).first()
         game = Game(id=game_id,
+                    season=season,
                     game_date=game_date,
                     game_json=game_json,
                     home_team=home_team,

--- a/nhl-game-predictor-backend/games/data_loader.py
+++ b/nhl-game-predictor-backend/games/data_loader.py
@@ -24,7 +24,6 @@ REVERSE_RESULT_MAP = {v: k for k, v in RESULT_MAP.items()}
 
 def convert_game_json_to_game_data_objects(game_json : dict, date_string : str, get_team_data : bool = False):
     game_id = game_json.get("id")
-    game_type = game_json.get("gameType")
     game_date = datetime.strptime(date_string, "%Y-%m-%d").date()
     current_date = timezone.localdate()
 
@@ -33,7 +32,7 @@ def convert_game_json_to_game_data_objects(game_json : dict, date_string : str, 
     home_team_goals = home_team_json.get("score", 0)
     away_team_goals = away_team_json.get("score", 0)
 
-    # only create game data when it is not preseason game and doesn't already exist
+    # only create game data when it doesn't already exist
     game = None
     home_team_data = None
     away_team_data = None
@@ -59,9 +58,11 @@ def convert_game_json_to_game_data_objects(game_json : dict, date_string : str, 
             away_team_data = load_team_data_for_date_from_api(team=away_team,
                                                               game_date=game_date)
             
-
+        
+        # assign game to season model
         season_id = game_json.get("season")
         season = Season.objects.filter(id=season_id).first()
+        
         game = Game(id=game_id,
                     season=season,
                     game_date=game_date,

--- a/nhl-game-predictor-backend/games/migrations/0026_assign_season_to_preseason_playoff_games.py
+++ b/nhl-game-predictor-backend/games/migrations/0026_assign_season_to_preseason_playoff_games.py
@@ -21,7 +21,20 @@ def assign_season_to_preseason_playoff_games(apps, schema_editor):
   Game.objects.bulk_update(games_to_update, fields=['season'])
 
 def unassign_season_to_preseason_playoff_games(apps, schema_editor):
-    pass
+  Game = apps.get_model('games', 'Game')
+
+  games_to_update = []
+
+  PRESEASON = 1
+  PLAYOFFS = 3
+
+  preseason_playoff_games = Game.objects.filter(game_json__gameType__in=[PRESEASON, PLAYOFFS])
+
+  for game in preseason_playoff_games:
+     game.season = None
+     games_to_update.append(game)
+
+  Game.objects.bulk_update(games_to_update, fields=['season'])
 
 class Migration(migrations.Migration):
 

--- a/nhl-game-predictor-backend/games/migrations/0026_assign_season_to_preseason_playoff_games.py
+++ b/nhl-game-predictor-backend/games/migrations/0026_assign_season_to_preseason_playoff_games.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+def assign_season_to_preseason_playoff_games(apps, schema_editor):
+  Game = apps.get_model('games', 'Game')
+  Season = apps.get_model('games', 'Season')
+
+  games_to_update = []
+
+  PRESEASON = 1
+  PLAYOFFS = 3
+
+  preseason_playoff_games = Game.objects.filter(game_json__gameType__in=[PRESEASON, PLAYOFFS])
+
+  for game in preseason_playoff_games:
+     game_season_id = game.game_json.get("season")
+     game.season = Season.objects.filter(season_id=game_season_id).first()
+     
+     if game.season is not None:
+        games_to_update.append(game)
+
+  Game.objects.bulk_update(games_to_update, fields=['season'])
+
+def unassign_season_to_preseason_playoff_games(apps, schema_editor):
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('games', '0025_load_preseason_playoff_games'),
+    ]
+
+    operations = [
+        migrations.RunPython(assign_season_to_preseason_playoff_games, reverse_code=unassign_season_to_preseason_playoff_games)
+    ]

--- a/nhl-game-predictor-backend/games/migrations/0026_assign_season_to_preseason_playoff_games.py
+++ b/nhl-game-predictor-backend/games/migrations/0026_assign_season_to_preseason_playoff_games.py
@@ -8,7 +8,7 @@ def assign_season_to_preseason_playoff_games(apps, schema_editor):
   PLAYOFFS = 3
 
   season_map = {
-      s.season_id: s
+      s.id: s
       for s in Season.objects.all()
   }
 


### PR DESCRIPTION
This PR:

- creates migration to assign Season object to all playoff and preseason games
- assigns a Season to a game in the `convert_game_json_to_game_data_objects` function in `data_loader.py`
closes #89 