### PR TITLE
Investigate Blank Feature Importances in Frontend

### DIFF
--- a/nhl-game-predictor-backend/predictor/ml_models/utils.py
+++ b/nhl-game-predictor-backend/predictor/ml_models/utils.py
@@ -76,6 +76,7 @@ class GameDataFrameEntry:
     """
 
     def __init__(self, game: Game):
+        self.game = game
         game_json = game.game_json
         home_team_data = game.home_team_data
         home_team_data_json = {} if home_team_data is None else home_team_data.team_data_json


### PR DESCRIPTION
This PR:

- ensures that categorical feature importances are handled appropriately (no duplicates or irrelevant columns such as `home_team_{id}` for a different home team)
- no longer limits the number of feature importances stored
- adds random state to `LimeTabularExplainer` to obtain deterministic results